### PR TITLE
Update of-watchdog 0.9.8 -> 0.9.10

### DIFF
--- a/template/puppeteer-node12/Dockerfile
+++ b/template/puppeteer-node12/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/of-watchdog:0.9.8 as watchdog
+FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/of-watchdog:0.9.10 as watchdog
 FROM --platform=${TARGETPLATFORM:-linux/amd64} buildkite/puppeteer:5.2.1
 
 ARG TARGETPLATFORM

--- a/template/puppeteer-nodelts/Dockerfile
+++ b/template/puppeteer-nodelts/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/of-watchdog:0.9.8 as watchdog
+FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/of-watchdog:0.9.10 as watchdog
 FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/puppeteer/puppeteer:18.2.1
 
 ARG TARGETPLATFORM


### PR DESCRIPTION
## Description
Update the of-watchdog to the latest version `0.9.10`

## Motivation
Support latest watchdog features like the /_/ready endpoint and ready proxy.